### PR TITLE
Refactoring power board code to avoid possible freeze

### DIFF
--- a/Dockerfile.stm32
+++ b/Dockerfile.stm32
@@ -6,7 +6,7 @@ RUN arduino-cli core update-index
 RUN arduino-cli core install STMicroelectronics:stm32@2.7.1
 RUN arduino-cli lib update-index
 RUN arduino-cli lib install "STM32duino FreeRTOS"@10.3.2
-RUN arduino-cli lib install "mcp_can"@1.5.1
+RUN arduino-cli lib install autowp-mcp2515@1.2.1
 RUN arduino-cli lib install "Dynamixel2Arduino"@0.5.3
 RUN arduino-cli lib install "Adafruit_VL53L0X"@1.2.4
 RUN arduino-cli lib install "Adafruit BusIO"@1.16.0

--- a/ais_stm32_power_board/ais_stm32_power_board.ino
+++ b/ais_stm32_power_board/ais_stm32_power_board.ino
@@ -551,7 +551,7 @@ void setup()
 
   semaphoreSequence = xSemaphoreCreateBinary();
   semaphoreCanISR = xSemaphoreCreateBinary();
-  semaphoreSerialCanIO = xSemaphoreCreateBinary();
+  semaphoreSerialCanIO = xSemaphoreCreateMutex();
 
   xTaskCreate(task_sequence,  "task_sequence",  configMINIMAL_STACK_SIZE, NULL, 5,  NULL);
   xTaskCreate(task_send,      "task_send",      configMINIMAL_STACK_SIZE, NULL, 9,  NULL);

--- a/ais_stm32_power_board/build.sh
+++ b/ais_stm32_power_board/build.sh
@@ -18,6 +18,7 @@ function help() {
     echo "-h         show this help"
     echo "-b <board> set board (default=STMicroelectronics:stm32:GenF3)"
     echo "-p <port>  set port (default=)"
+    echo "-d         debug mode (Seria.print)"
 }
 
 : ${ARDUINO_BOARD:="STMicroelectronics:stm32:GenF3"}
@@ -25,8 +26,9 @@ function help() {
 
 board=$ARDUINO_BOARD
 port=$ARDUINO_PORT
+debug=
 
-while getopts "hb:p:" arg; do
+while getopts "hb:p:d" arg; do
     case $arg in
 	h)
 	    help
@@ -38,6 +40,9 @@ while getopts "hb:p:" arg; do
 	p)
 	    port=$OPTARG
 	    ;;
+    d)
+        debug="--build-property build.extra_flags=-DDEBUG=1"
+        ;;
     esac
 done
 shift $((OPTIND-1))
@@ -49,8 +54,8 @@ fi
 
 function build() {
     echo "building..."
-    echo "arduino-cli compile -b $board ."
-    arduino-cli compile -b $board .
+    echo "arduino-cli compile -b $board $debug ."
+    arduino-cli compile -b $board $debug .
 
     if [ $? -ne 0 ]; then
 	err "Please check board ($board)"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - ARDUINO_BOARD
       - ARDUINO_PORT
     volumes:
-      - ./ais_esp32_sensor_board_proto:/mnt/ais_esp32_sensor_board_proto
+      - ./ais_esp32_sensor_board:/mnt/ais_esp32_sensor_board
       - /dev:/dev
       - /sys/devices:/sys/devices
 # required for display or device
@@ -20,7 +20,7 @@ services:
       - /dev/dri
 # device, bluetooth
     network_mode: host
-    working_dir: /mnt/ais_esp32_sensor_board_proto
+    working_dir: /mnt/ais_esp32_sensor_board
     command:
       - "bash"
 
@@ -47,17 +47,17 @@ services:
   stm32-handle:
     extends: stm32
     volumes:
-      - ./ais_stm32_handle_board_proto:/mnt/ais_stm32_handle_board_proto
-    working_dir: /mnt/ais_stm32_handle_board_proto
+      - ./ais_stm32_handle_board:/mnt/ais_stm32_handle_board
+    working_dir: /mnt/ais_stm32_handle_board
 
   stm32-power:
     extends: stm32
     volumes:
-      - ./ais_stm32_power_board_proto:/mnt/ais_stm32_power_board_proto
-    working_dir: /mnt/ais_stm32_power_board_proto
+      - ./ais_stm32_power_board:/mnt/ais_stm32_power_board
+    working_dir: /mnt/ais_stm32_power_board
 
   stm32-thermo:
     extends: stm32
     volumes:
-      - ./ais_stm32_thermo_board_proto:/mnt/ais_stm32_thermo_board_proto
-    working_dir: /mnt/ais_stm32_thermo_board_proto
+      - ./ais_stm32_thermo_board:/mnt/ais_stm32_thermo_board
+    working_dir: /mnt/ais_stm32_thermo_board


### PR DESCRIPTION
- docker containerでのビルドができるように更新しました
- `Serial.print/println`は`DEBUG=1`の時だけ使うようにしました
  - `debug_print/debug_println`という関数を作っています
  - `Serial.print`の最中にタスクが切り替わる可能性は否定できないので ~~`taskENTER_CRITICAL/taskEXIT_CRITICAL`~~ `xSemaphoreTake/xSemaphoreGive/` で囲っています
- `mcpISR`はセマフォをgiveするだけに変更しました
- `task_read`を`task_send`よりも優先度を高くし、かつセマフォの委譲先がすぐに実行されるようにしています
- `mcp2515.readMessage` と `mcp2515.sendMessage` も同時に動くとまずいので ~~`taskENTER_CRITICAL/taskEXIT_CRITICAL`~~ `xSemaphoreTake/xSemaphoreGive/`で囲っています
- interruptを処理した時にすでに二つのバッファーが埋まっている状況を考慮して、CANのリード処理を変えました
  - getInterruptsを取得して、RXB0/RXB1のどちらかにデータがある場合にはデータを処理し、ない場合には待つようにしました
- `mcp2515.clearInterrupts`は ~~呼ぶ必要がなさそうなので~~ 呼ぶと片方にデータが残っていた場合に読めなくなるのでコメントアウトしています
- [x] semaphoreCanIO, SemaphoreSerialを交互に待つデッドロックが起こる可能性があるので、まとめる